### PR TITLE
fix(build): ensure GTK portal service starts with Niri session

### DIFF
--- a/build/24-niri-services.sh
+++ b/build/24-niri-services.sh
@@ -10,8 +10,14 @@ set -eoux pipefail
 
 echo "::group:: Configure Portal Services"
 
-# Unmask and enable GTK portal for Niri
-systemctl --user unmask xdg-desktop-portal-gtk.service || true
+# Ensure GTK portal is not masked (build-time mask removal)
+mkdir -p "/etc/systemd/user"
+rm -f "/etc/systemd/user/xdg-desktop-portal-gtk.service" || true
+
+# Enable GTK portal for file chooser in Niri
+mkdir -p "/etc/systemd/user/graphical-session.target.wants"
+ln -sf "/usr/lib/systemd/user/xdg-desktop-portal-gtk.service" \
+    "/etc/systemd/user/graphical-session.target.wants/xdg-desktop-portal-gtk.service" || true
 
 echo "::endgroup::"
 echo "::group:: Configure Niri Session Services"


### PR DESCRIPTION
- Removes any mask on the GTK portal service at build time
- Enables it in the graphical session target so it starts automatically when user logged in
- Hopefully make the GTK filechooser work