### PR TITLE
fix(portal): ensure GTK portal service starts with Niri session

### DIFF
--- a/system_files/usr/lib/systemd/user/xdg-desktop-portal-gtk.service
+++ b/system_files/usr/lib/systemd/user/xdg-desktop-portal-gtk.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Portal service (GTK/GNOME implementation)
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.impl.portal.desktop.gtk
+ExecStart=/usr/libexec/xdg-desktop-portal-gtk
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
Fixes xdg-desktop-portal-gtk not starting with Niri session by:
1. Creating service file with [Install] section
2. Enabling it in graphical-session.target
3. Adding dependency on niri.service to ensure display is available