### PR TITLE
fix(service): use export for display environment

### DIFF
--- a/system_files/usr/lib/systemd/user/display-environment.service
+++ b/system_files/usr/lib/systemd/user/display-environment.service
@@ -6,7 +6,7 @@ Requisite=graphical-session.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'sleep 3; WAYLAND_DISPLAY=wayland-1; DISPLAY=:1; XDG_CURRENT_DESKTOP=niri; XDG_SESSION_TYPE=wayland; systemctl --user import-environment WAYLAND_DISPLAY DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE 2>/dev/null || true; systemctl --user restart xdg-desktop-portal-gtk.service 2>/dev/null || true; systemctl --user restart xdg-desktop-portal-cosmic.service 2>/dev/null || true'
+ExecStart=/bin/sh -c 'sleep 3; export WAYLAND_DISPLAY=wayland-1; export DISPLAY=:1; export XDG_CURRENT_DESKTOP=niri; export XDG_SESSION_TYPE=wayland; systemctl --user import-environment WAYLAND_DISPLAY DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE 2>/dev/null || true; sleep 2; systemctl --user restart xdg-desktop-portal-gtk.service 2>/dev/null || true; systemctl --user restart xdg-desktop-portal-cosmic.service 2>/dev/null || true; sleep 2; systemctl --user restart xdg-desktop-portal.service 2>/dev/null || true'
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
fixed environment import syntax, uses export to set variables in shell, then import-environment to import them. added portal restart timing as well to prevents main portal timeout.