### PR TITLE
chore(conf): refactor portal management with centralized setup script

### DIFF
--- a/system_files/usr/lib/systemd/user/display-environment.service
+++ b/system_files/usr/lib/systemd/user/display-environment.service
@@ -6,7 +6,7 @@ Requisite=graphical-session.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'sleep 3; export WAYLAND_DISPLAY=wayland-1; export DISPLAY=:1; export XDG_CURRENT_DESKTOP=niri; export XDG_SESSION_TYPE=wayland; systemctl --user import-environment WAYLAND_DISPLAY DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE 2>/dev/null || true; sleep 2; systemctl --user restart xdg-desktop-portal-gtk.service 2>/dev/null || true; systemctl --user restart xdg-desktop-portal-cosmic.service 2>/dev/null || true; sleep 2; systemctl --user restart xdg-desktop-portal.service 2>/dev/null || true'
+ExecStart=/bin/sh -c 'sleep 3; export WAYLAND_DISPLAY=wayland-1; export DISPLAY=:1; export XDG_CURRENT_DESKTOP=niri; export XDG_SESSION_TYPE=wayland; systemctl --user import-environment WAYLAND_DISPLAY DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE 2>/dev/null || true; sleep 2; /usr/lib/systemd/user/setup-portals.sh'
 RemainAfterExit=yes
 
 [Install]

--- a/system_files/usr/lib/systemd/user/setup-portals.sh
+++ b/system_files/usr/lib/systemd/user/setup-portals.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Combined portal setup and compositor detection script
+# Usage: setup-portals.sh [desktop_name]
+# If desktop_name is provided, skips detection and uses it
+
+set -euo pipefail
+
+# Robust Wayland compositor detection
+detect_compositor() {
+    # Method 1: Check running processes (most reliable after compositor startup)
+    if pgrep -f "cosmic-comp" > /dev/null 2>&1; then
+        echo "COSMIC"
+        return 0
+    fi
+    
+    if pgrep -f "niri" > /dev/null 2>&1; then
+        echo "Niri"
+        return 0
+    fi
+    
+    # Method 2: Check session from loginctl (may not be available immediately)
+    SESSION_ID=$(loginctl user-status | head -1 | awk '{print $1}')
+    if [ -n "$SESSION_ID" ]; then
+        SESSION_DESKTOP=$(loginctl show-session "$SESSION_ID" -p Desktop 2>/dev/null | cut -d= -f2)
+        case "$SESSION_DESKTOP" in
+            "COSMIC")
+                echo "COSMIC"
+                return 0
+                ;;
+            "Niri")
+                echo "Niri"
+                return 0
+                ;;
+        esac
+    fi
+    
+    # Method 3: Fallback to environment variables
+    echo "${XDG_CURRENT_DESKTOP:-${XDG_SESSION_DESKTOP:-Niri}}"
+}
+
+# Main setup function
+setup_portals() {
+    local desktop="$1"
+    echo "Setting up portals for desktop: $desktop"
+    
+    local portal_config_dir="/usr/share/xdg-desktop-portal"
+    local user_config="/run/user/$(id -u)/xdg-desktop-portal.conf"
+    
+    case "$desktop" in
+        "COSMIC")
+            echo "Using COSMIC portal configuration"
+            if [ -f "$portal_config_dir/cosmic-portals.conf" ]; then
+                cp "$portal_config_dir/cosmic-portals.conf" "$user_config"
+            fi
+            # Enable COSMIC portal service
+            systemctl --user enable xdg-desktop-portal-cosmic.service 2>/dev/null || true
+            systemctl --user disable xdg-desktop-portal-gnome.service 2>/dev/null || true
+            ;;
+        "Niri")
+            echo "Using Niri (GNOME) portal configuration"
+            if [ -f "$portal_config_dir/niri-portals.conf" ]; then
+                cp "$portal_config_dir/niri-portals.conf" "$user_config"
+            fi
+            # Enable GNOME portal service
+            systemctl --user enable xdg-desktop-portal-gnome.service 2>/dev/null || true
+            systemctl --user disable xdg-desktop-portal-cosmic.service 2>/dev/null || true
+            ;;
+        *)
+            echo "Unknown desktop '$desktop', using default GNOME configuration"
+            if [ -f "$portal_config_dir/niri-portals.conf" ]; then
+                cp "$portal_config_dir/niri-portals.conf" "$user_config"
+            fi
+            systemctl --user enable xdg-desktop-portal-gnome.service 2>/dev/null || true
+            systemctl --user disable xdg-desktop-portal-cosmic.service 2>/dev/null || true
+            ;;
+    esac
+    
+    # Restart main portal service
+    systemctl --user restart xdg-desktop-portal.service 2>/dev/null || true
+    echo "Portal setup completed"
+}
+
+# Main execution
+main() {
+    local desktop
+    
+    if [ $# -eq 1 ]; then
+        desktop="$1"
+        echo "Using provided desktop: $desktop"
+    else
+        desktop=$(detect_compositor)
+        echo "Detected desktop: $desktop"
+    fi
+    
+    setup_portals "$desktop"
+}
+
+# Run main function with all arguments
+main "$@"

--- a/system_files/usr/share/xdg-desktop-portal/cosmic-portals.conf
+++ b/system_files/usr/share/xdg-desktop-portal/cosmic-portals.conf
@@ -1,0 +1,10 @@
+[preferred]
+default=cosmic;
+org.freedesktop.impl.portal.Access=cosmic;
+org.freedesktop.impl.portal.Notification=cosmic;
+org.freedesktop.impl.portal.Secret=gnome-keyring;
+org.freedesktop.impl.portal.FileChooser=cosmic;
+org.freedesktop.impl.portal.Screenshot=cosmic;
+org.freedesktop.impl.portal.ScreenCast=cosmic;
+org.freedesktop.impl.portal.Inhibit=cosmic;
+org.freedesktop.impl.portal.Background=cosmic;

--- a/system_files/usr/share/xdg-desktop-portal/niri-portals.conf
+++ b/system_files/usr/share/xdg-desktop-portal/niri-portals.conf
@@ -1,10 +1,10 @@
 [preferred]
 default=gnome;
 org.freedesktop.impl.portal.Access=gnome;
-org.freedesktop.impl.portal.Notification=gnome;cosmic;
+org.freedesktop.impl.portal.Notification=gnome;
 org.freedesktop.impl.portal.Secret=gnome-keyring;
 org.freedesktop.impl.portal.FileChooser=gnome;
 org.freedesktop.impl.portal.Screenshot=gnome;
-org.freedesktop.impl.portal.ScreenCast=cosmic;gnome;
+org.freedesktop.impl.portal.ScreenCast=gnome;
 org.freedesktop.impl.portal.Inhibit=gnome;
 org.freedesktop.impl.portal.Background=gnome;


### PR DESCRIPTION
- Replace inline portal restart commands with dedicated setup-portals.sh script
- Add robust compositor detection (process checking, loginctl, env vars)
- Create separate portal configs for COSMIC and Niri desktops
- Simplify display-environment.service to use centralized portal setup
- Clean up niri-portals.conf to remove cosmic fallbacks
- Add automatic service enable/disable based on detected desktop