### PR TITLE
fix(keyring): adjust cosmic-greeter auth modules

### DIFF
--- a/system_files/etc/pam.d/cosmic-greeter
+++ b/system_files/etc/pam.d/cosmic-greeter
@@ -1,13 +1,13 @@
 #%PAM-1.0
-auth       required   pam_shells.so
-auth       requisite  pam_nologin.so
+auth       optional   pam_shells.so
+auth       optional   pam_nologin.so
 auth       sufficient pam_fprintd.so
 auth       sufficient pam_unix.so try_first_pass
 auth       optional   pam_permit.so
 auth       optional   pam_gnome_keyring.so
 
-account    required   pam_nologin.so
-account    include    system-account
+account    optional   pam_nologin.so
+account    required   pam_unix.so
 
 password   sufficient pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 password   sufficient pam_fprintd.so


### PR DESCRIPTION
Replace missing system-account include with pam_unix.so and make shell/nologin checks optional to prevent authentication failures/improve login reliability