### PR TITLE
fix(keyring): adjust auth permission for gnome-keyring PAM

### DIFF
--- a/system_files/etc/pam.d/cosmic-greeter
+++ b/system_files/etc/pam.d/cosmic-greeter
@@ -2,9 +2,9 @@
 auth       optional   pam_shells.so
 auth       optional   pam_nologin.so
 auth       sufficient pam_fprintd.so
-auth       sufficient pam_unix.so try_first_pass
-auth       optional   pam_permit.so
+auth       required   pam_unix.so try_first_pass
 auth       optional   pam_gnome_keyring.so
+auth       optional   pam_permit.so
 
 account    optional   pam_nologin.so
 account    required   pam_unix.so


### PR DESCRIPTION
(currently I can log in but when I open Chromium/Zed i still need to reinsert password)