### PR TITLE
fix(service): sort service run deps order

### DIFF
--- a/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
+++ b/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=COSMIC Alternative Startup Service
 PartOf=graphical-session.target
-After=graphical-session.target display-environment.service
+After=graphical-session.target display-environment.service cosmic-session.target
 Requisite=graphical-session.target
 Wants=display-environment.service
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
 
 [Service]
 Environment=XDG_SESSION_TYPE=wayland
-Environment=COSMIC_SESSION_SOCKET_DIR=%t/cosmic-session
 ExecStart=/usr/bin/cosmic-ext-alternative-startup
 Restart=on-failure
 RestartSec=5

--- a/system_files/usr/lib/systemd/user/cosmic-ext-bg-theme.service
+++ b/system_files/usr/lib/systemd/user/cosmic-ext-bg-theme.service
@@ -2,9 +2,9 @@
 Description=COSMIC Background Theme Service
 Documentation=man:cosmic-ext-bg-theme(1)
 PartOf=graphical-session.target
-After=graphical-session.target display-environment.service xdg-desktop-portal.service
+After=graphical-session.target display-environment.service xdg-desktop-portal.service cosmic-ext-alternative-startup.service
 Requisite=graphical-session.target
-Wants=xdg-desktop-portal.service
+Wants=xdg-desktop-portal.service cosmic-ext-alternative-startup.service
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
 
 [Service]


### PR DESCRIPTION
Making sure cosmic-session start first → cosmic-ext-alternative-startup can start afterwards → cosmic-ext-bg-theme can get the needed dependencies once cosmic-session & cosmic-settings daemon runs