### PR TITLE
feat(service): add cosmic-session service

### DIFF
--- a/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
+++ b/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=COSMIC Alternative Startup Service
 PartOf=graphical-session.target
-After=graphical-session.target display-environment.service cosmic-session.target
-Requisite=graphical-session.target
+After=cosmic-session.service display-environment.service
+Requisite=cosmic-session.service
 Wants=display-environment.service
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
 

--- a/system_files/usr/lib/systemd/user/cosmic-session.service
+++ b/system_files/usr/lib/systemd/user/cosmic-session.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=COSMIC Session Manager
+Documentation=man:cosmic-session(1)
+BindsTo=graphical-session.target
+After=graphical-session-pre.target
+Before=graphical-session.target
+ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/cosmic-session niri
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session-pre.target


### PR DESCRIPTION
then let cosmic-ext-alternative-startup run with cosmic-session.service as its requisite