### PR TITLE
fix(service): free cosmic-session from requisites

### DIFF
--- a/build/23-system-files.sh
+++ b/build/23-system-files.sh
@@ -77,11 +77,6 @@ systemctl preset-all --global || true
 # Configure Niri session services
 mkdir -p /usr/lib/systemd/user/niri.service.wants
 
-# Core session manager
-if [ -f /usr/lib/systemd/user/cosmic-session.service ]; then
-    ln -sf /usr/lib/systemd/user/cosmic-session.service /usr/lib/systemd/user/niri.service.wants/cosmic-session.service
-fi
-
 # COSMIC components
 if [ -f /usr/lib/systemd/user/cosmic-ext-alternative-startup.service ]; then
     ln -sf /usr/lib/systemd/user/cosmic-ext-alternative-startup.service /usr/lib/systemd/user/niri.service.wants/cosmic-ext-alternative-startup.service

--- a/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
+++ b/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=COSMIC Alternative Startup Service
 PartOf=graphical-session.target
-After=cosmic-session.service
-Requisite=cosmic-session.service
+After=graphical-session.target
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
 
 [Service]

--- a/system_files/usr/lib/systemd/user/cosmic-session.service
+++ b/system_files/usr/lib/systemd/user/cosmic-session.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=COSMIC Session Manager
 Documentation=man:cosmic-session(1)
-PartOf=graphical-session.target
 After=graphical-session.target
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
 


### PR DESCRIPTION
rely on cosmic-ext-alternative-startup to spawn cosmic-session in the right way for niri