### PR TITLE
fix(service): make bg-service run separately

### DIFF
--- a/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
+++ b/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
@@ -5,10 +5,11 @@ After=graphical-session.target
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
 
 [Service]
+Type=simple
 Environment=XDG_SESSION_TYPE=wayland
 ExecStart=/usr/bin/cosmic-ext-alternative-startup
 Restart=on-failure
-RestartSec=5
+RestartSec=10
 
 [Install]
 WantedBy=graphical-session.target

--- a/system_files/usr/lib/systemd/user/cosmic-ext-bg-theme.service
+++ b/system_files/usr/lib/systemd/user/cosmic-ext-bg-theme.service
@@ -2,8 +2,7 @@
 Description=COSMIC Background Theme Service
 Documentation=man:cosmic-ext-bg-theme(1)
 PartOf=graphical-session.target
-After=cosmic-ext-alternative-startup.service
-Requisite=cosmic-ext-alternative-startup.service
+After=graphical-session.target
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
 
 [Service]
@@ -11,7 +10,7 @@ Type=simple
 Environment=XDG_SESSION_TYPE=wayland
 ExecStart=/usr/bin/cosmic-ext-bg-theme
 Restart=on-failure
-RestartSec=5
+RestartSec=10
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
not requiring cosmic-ext-alternative-startup at all, but will retry it after timeout is done