### PR TITLE
fix(session): add manual gnome-keyring startup for niri]

### DIFF
--- a/system_files/usr/bin/start-cosmic-ext-niri
+++ b/system_files/usr/bin/start-cosmic-ext-niri
@@ -46,19 +46,13 @@ if command -v systemctl >/dev/null; then
     systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 fi
 
-# Start gnome keyring components if the daemon is active
-# -> check if /run/user/$UID/keyring exists
-if [ -d "/run/user/$(id -u)/keyring" ]; then
-
-    # Use PATH lookup instead of hardcoding /usr/bin
+# Start gnome keyring components if daemon is active
+if [ -d "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/keyring" ]; then
     if command -v gnome-keyring-daemon >/dev/null 2>&1; then
-        eval "$(gnome-keyring-daemon --start --components=pkcs11,secrets,ssh > /dev/null 2>&1)"
+        eval "$(gnome-keyring-daemon --start --components=pkcs11,secrets,ssh)"
     else
         echo "gnome-keyring-daemon not found in PATH" >&2
     fi
-
-    # Set SSH_AUTH_SOCK to the standard gnome-keyring socket
-    export SSH_AUTH_SOCK="/run/user/$(id -u)/keyring/ssh"
 fi
 
 # Run cosmic-session

--- a/system_files/usr/bin/start-cosmic-ext-niri
+++ b/system_files/usr/bin/start-cosmic-ext-niri
@@ -45,6 +45,22 @@ if command -v systemctl >/dev/null; then
     # set environment variables for new units started by user service manager
     systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 fi
+
+# Start gnome keyring components if the daemon is active
+# -> check if /run/user/$UID/keyring exists
+if [ -d "/run/user/$(id -u)/keyring" ]; then
+
+    # Use PATH lookup instead of hardcoding /usr/bin
+    if command -v gnome-keyring-daemon >/dev/null 2>&1; then
+        eval "$(gnome-keyring-daemon --start --components=pkcs11,secrets,ssh > /dev/null 2>&1)"
+    else
+        echo "gnome-keyring-daemon not found in PATH" >&2
+    fi
+
+    # Set SSH_AUTH_SOCK to the standard gnome-keyring socket
+    export SSH_AUTH_SOCK="/run/user/$(id -u)/keyring/ssh"
+fi
+
 # Run cosmic-session
 if [[ -z "${DBUS_SESSION_BUS_ADDRESS}" ]]; then
     exec /usr/bin/dbus-run-session -- /usr/bin/cosmic-session niri

--- a/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
+++ b/system_files/usr/lib/systemd/user/cosmic-ext-alternative-startup.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=COSMIC Alternative Startup for Niri
-BindsTo=niri.service
-After=niri.service
+BindsTo=cosmic-niri-session.service
+After=cosmic-niri-session.service
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
 
 [Service]
@@ -11,4 +11,4 @@ Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=niri.service
+WantedBy=cosmic-niri-session.service

--- a/system_files/usr/lib/systemd/user/cosmic-niri-session.service
+++ b/system_files/usr/lib/systemd/user/cosmic-niri-session.service
@@ -3,7 +3,7 @@ Description=COSMIC Session Manager
 Documentation=man:cosmic-session(1)
 After=graphical-session.target
 ConditionEnvironment=XDG_CURRENT_DESKTOP=niri
-Wants=swayidle.service cosmic-notifications.service waybar.service
+Wants=swayidle.service cosmic-notifications.service waybar.service cosmic-ext-alternative-startup.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
[fix(session): add manual gnome-keyring startup for niri](https://github.com/KiKaraage/cosmoneer/commit/11be3811ffdb50fdb0189048b33b81c99987fe0f) 

PAM auto_start only starts pkcs11 component. Add manual gnome-keyring-daemon startup to ensure all components (pkcs11, secrets, ssh) are started and unlocked with login password. Addresses password prompt on keyring access in niri session.

[fix(service): bind alt-startup to cosmic-niri-session](https://github.com/KiKaraage/cosmoneer/commit/73326e40f76286bc2ab3a2302cb954b765408cea) 

*both by GLM 4.7 in OpenCode*